### PR TITLE
enforce flag name length

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -130,8 +130,27 @@ func (c *Component) init() {
 	}
 }
 
+func (c *Component) validate(output io.Writer) bool {
+	ok := true
+	for _, f := range c.Flags {
+		if len(f.Long) == 1 {
+			writef(output, "babycli: long flag %q must be more than one character", f.Long)
+			ok = false
+		}
+		if len(f.Short) > 1 {
+			writef(output, "babycli: short flag %q must be one character", f.Short)
+			ok = false
+		}
+	}
+	return ok
+}
+
 func (c *Component) run(output io.Writer) *result {
 	c.init()
+
+	if !c.validate(output) {
+		return &result{code: Failure}
+	}
 
 	for !c.args.Empty() {
 		if more := c.processFlags(); !more {

--- a/commands.go
+++ b/commands.go
@@ -130,21 +130,6 @@ func (c *Component) init() {
 	}
 }
 
-func (c *Component) validate(output io.Writer) bool {
-	ok := true
-	for _, f := range c.Flags {
-		if len(f.Long) == 1 {
-			writef(output, "babycli: long flag %q must be more than one character", f.Long)
-			ok = false
-		}
-		if len(f.Short) > 1 {
-			writef(output, "babycli: short flag %q must be one character", f.Short)
-			ok = false
-		}
-	}
-	return ok
-}
-
 func (c *Component) run(output io.Writer) *result {
 	c.init()
 

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,36 @@
+// Copyright (c) The Noxide Project Authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package babycli
+
+import (
+	"io"
+)
+
+func (c *Component) validate(output io.Writer) bool {
+	ok := true
+
+	for _, f := range c.Flags {
+		if len(f.Long) == 1 {
+			writef(output, "babycli: long flag %q must be more than one character", f.Long)
+			ok = false
+		}
+		if len(f.Short) > 1 {
+			writef(output, "babycli: short flag %q must be one character", f.Short)
+			ok = false
+		}
+	}
+
+	for _, cmd := range c.Components {
+		switch len(cmd.Name) {
+		case 0:
+			writef(output, "babycli: component name missing")
+			ok = false
+		case 1:
+			writef(output, "babycli: component %q must be more than one character", cmd.Name)
+			ok = false
+		}
+	}
+
+	return ok
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) The Noxide Project Authors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package babycli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestComponent_validate_short_flag(t *testing.T) {
+	t.Parallel()
+
+	config := &Configuration{
+		Top: &Component{
+			Flags: Flags{
+				{
+					Long:  "long",
+					Short: "xyz",
+				},
+			},
+		},
+	}
+
+	w := new(bytes.Buffer)
+	c := New(config)
+	c.output = w
+
+	result := c.Run()
+	must.One(t, result)
+	message := strings.TrimSpace(w.String())
+	must.Eq(t, `babycli: short flag "xyz" must be one character`, message)
+}
+
+func TestComponent_validate_long_flag(t *testing.T) {
+	t.Parallel()
+
+	config := &Configuration{
+		Top: &Component{
+			Flags: Flags{
+				{
+					Long:  "x",
+					Short: "z",
+				},
+			},
+		},
+	}
+
+	w := new(bytes.Buffer)
+	c := New(config)
+	c.output = w
+
+	result := c.Run()
+	must.One(t, result)
+	message := strings.TrimSpace(w.String())
+	must.Eq(t, `babycli: long flag "x" must be more than one character`, message)
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -58,3 +58,55 @@ func TestComponent_validate_long_flag(t *testing.T) {
 	message := strings.TrimSpace(w.String())
 	must.Eq(t, `babycli: long flag "x" must be more than one character`, message)
 }
+
+func TestComponent_validate_name_empty(t *testing.T) {
+	t.Parallel()
+
+	config := &Configuration{
+		Top: &Component{
+			Components: Components{
+				{
+					Name: "first",
+				},
+				{
+					Name: "",
+				},
+			},
+		},
+	}
+
+	w := new(bytes.Buffer)
+	c := New(config)
+	c.output = w
+
+	result := c.Run()
+	must.One(t, result)
+	message := strings.TrimSpace(w.String())
+	must.Eq(t, `babycli: component name missing`, message)
+}
+
+func TestComponent_validate_name_single(t *testing.T) {
+	t.Parallel()
+
+	config := &Configuration{
+		Top: &Component{
+			Components: Components{
+				{
+					Name: "first",
+				},
+				{
+					Name: "x",
+				},
+			},
+		},
+	}
+
+	w := new(bytes.Buffer)
+	c := New(config)
+	c.output = w
+
+	result := c.Run()
+	must.One(t, result)
+	message := strings.TrimSpace(w.String())
+	must.Eq(t, `babycli: component "x" must be more than one character`, message)
+}


### PR DESCRIPTION
- flags: ensure short and long flag lengths are sensible
- components: ensure commands have a lengthy name
